### PR TITLE
Fix requirements.txt for Python 3.14 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-Pillow==8.4.0
-Flask==2.1.1
-tk==8.6.12
+Pillow>=10.0.0
+Flask>=3.0.0


### PR DESCRIPTION
## Summary
- Update Pillow from pinned 8.4.0 to >=10.0.0 (old version fails to build on Python 3.14)
- Update Flask from pinned 2.1.1 to >=3.0.0
- Remove `tk==8.6.12` which is not a valid pip package (Tkinter comes bundled with Python)

## Test plan
- [x] Tested with Python 3.14 - `pip install -r requirements.txt` succeeds
- [x] Verified demo app runs correctly after installation

🤖 Generated with [Claude Code](https://claude.ai/code)